### PR TITLE
Solve the problem of consuming too much gpu memory

### DIFF
--- a/openhgnn/config.ini
+++ b/openhgnn/config.ini
@@ -135,22 +135,41 @@ max_epoch = 500
 patience = 40
 mini_batch_flag = False
 
+;[MAGNN]
+;seed = 0
+;learning_rate = 0.005
+;weight_decay = 0.001
+;dropout = 0.2
+;
+;hidden_dim = 32
+;out_dim = 16
+;inter_attn_feats = 32
+;num_heads = 4
+;num_layers = 2
+;
+;max_epoch = 500
+;patience = 40
+;mini_batch_flag = False
+;encoder_type = Linear
+
+; best config
 [MAGNN]
 seed = 0
 learning_rate = 0.005
-weight_decay = 0.001
-dropout = 0.2
+weight_decay = 0.001 
+dropout = 0.5 
 
-hidden_dim = 32
-out_dim = 16
-inter_attn_feats = 32
-num_heads = 4
-num_layers = 2
+hidden_dim = 64
+out_dim = 3 
+			 
+inter_attn_feats = 128 
+num_heads = 8 
+num_layers = 2 
 
-max_epoch = 500
-patience = 40
+max_epoch = 100
+patience = 30
 mini_batch_flag = False
-encoder_type = Linear
+encoder_type = RotateE
 
 [HGT]
 seed = 0

--- a/openhgnn/config.py
+++ b/openhgnn/config.py
@@ -170,7 +170,7 @@ class Config(object):
             self.inter_attn_feats = conf.getint("MAGNN", "inter_attn_feats")
             self.hidden_dim = conf.getint('MAGNN', 'hidden_dim')
             self.out_dim = conf.getint('MAGNN', 'out_dim')
-            self.num_heads = conf.get('MAGNN', 'num_heads')
+            self.num_heads = conf.getint('MAGNN', 'num_heads')
             self.num_layers = conf.getint("MAGNN", "num_layers")
 
             self.patience = conf.getint('MAGNN', 'patience')

--- a/openhgnn/models/MAGNN.py
+++ b/openhgnn/models/MAGNN.py
@@ -48,7 +48,7 @@ class MAGNN(BaseModel):
         return cls(in_feats=in_feats,
                    h_feats=args.hidden_dim,
                    inter_attn_feats=args.inter_attn_feats,
-                   num_heads=args.inter_attn_feats,
+                   num_heads=args.num_heads,
                    num_classes=args.out_dim,
                    num_layers=args.num_layers,
                    metapath_list=metapath_list,


### PR DESCRIPTION
- fix some bugs related to 'num_heads' in config
- change the config in config.ini to the best config and leave the original config as comments.
- solve the problem of consuming too much gpu memory of MAGNN on imdb4MAGNN dataset. The maximal gpu memory consumption is limited to 13GB (on imdb4MAGNN). 