### PR TITLE
[Fix]: GTN, fastGTN, MHNF model 'RuntimeError' when using gpu

### DIFF
--- a/openhgnn/utils/utils.py
+++ b/openhgnn/utils/utils.py
@@ -276,7 +276,7 @@ def transform_relation_graph_list(hg, category, identity=True):
             category_id = i
     g = dgl.to_homogeneous(hg, ndata='h')
     # find out the target node ids in g
-    loc = (g.ndata[dgl.NTYPE] == category_id)
+    loc = (g.ndata[dgl.NTYPE] == category_id).to('cpu')
     category_idx = th.arange(g.num_nodes())[loc]
 
     edges = g.edges()


### PR DESCRIPTION
## Description
<!-- Brief description. Refer to the related issues if existed.
It'll be great if relevant reviewers can be assigned as well.-->
Fix the 'RuntimeError: indices should be either on cpu or on the same device as the indexed tensor (cpu)' problem for [GTN] [fastGTN] [MHNF] models.
## Checklist
Please feel free to remove inapplicable items for your PR.
- [x] The PR title starts with [$CATEGORY] (such as [NN], [Model], [Doc], [Feature]])
- [x] Changes are complete (i.e. I finished coding on this PR)
- [x] All changes have test coverage
- [ ] Code is well-documented
- [x] To the best of my knowledge, examples are either not affected by this change, or have been fixed to be compatible with this change
- [ ] Related issue is referred in this PR
- [ ] If the PR is for a new model/paper, I've updated the example index [here](../README.md).

## Changes
<!-- You could use following template
- [ ] Feature1, tests, (and when applicable, API doc)
- [ ] Feature2, tests, (and when applicable, API doc)
-->
