### PR TITLE
[Model] Add HCAN and D-HCAN

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ OpenHGNN是一个基于 [DGL [Deep Graph Library]](https://github.com/dmlc/dgl) 
 我们更新了0.9版本。
 
 - 新增10个模型贡献，对应11个注册模型名：HGDL、HGEN、HGSketch、HGOT、RMR、HERO/HERO_homo、SEHTGNN、HTGformer、HCMGNN、RelGT。
-- 当前版本共注册83个模型名和17个任务/流程入口。
+- 当前版本共注册86个模型名和17个任务/流程入口。
 - 新增 `node_regression` 任务，支持连续值节点标签预测。
 - 更新文档入口、快速开始、模型导览、任务导览和模型PR审查规范。
 - 加强模型贡献的标准化检查，包括DGL实现、trainerflow、dataset、README和smoke test要求。
@@ -163,7 +163,7 @@ OpenHGNN荣获启智社区优秀孵化项⽬奖！详细链接：https://mp.weix
 
 当前版本统计：
 
-- 注册模型名：83个。
+- 注册模型名：86个。
 - 注册任务/流程入口：17个。
 - v0.9新增模型贡献：10个，其中 `HERO` 和 `HERO_homo` 是同一模型贡献下的两个注册名。
 - v0.9新增任务：`node_regression`。
@@ -346,7 +346,7 @@ python main.py -m MAGNN -d imdb4MAGNN -t node_classification -g 0 --use_best_con
 
 ### Supported Models with specific task / 特定任务下支持的模型
 
-当前版本共注册83个模型名。下表列出README中维护的主要模型与任务覆盖情况；完整注册列表可以通过 `openhgnn list models` 查看。表格中的链接给出了模型的基本使用方法。
+当前版本共注册86个模型名。下表列出README中维护的主要模型与任务覆盖情况；完整注册列表可以通过 `openhgnn list models` 查看。表格中的链接给出了模型的基本使用方法。
 
 | 模型 | 节点分类 | 链路预测 | 推荐 | 节点回归 | 其他/说明 |
 | --- | --- | --- | --- | --- | --- |
@@ -382,6 +382,8 @@ python main.py -m MAGNN -d imdb4MAGNN -t node_classification -g 0 --use_best_con
 | [HetSANN](./openhgnn/output/HGT)[AAAI 2020] | :heavy_check_mark: |  |  |  |  |
 | [ieHGCN](./openhgnn/output/HGT)[TKDE 2021] | :heavy_check_mark: |  |  |  |  |
 | [KTN](./openhgnn/output/KTN)[NeurIPS 2022] | :heavy_check_mark: |  |  |  |  |
+| [HCAN](./docs/source/models/hcan.rst)[ICDE 2025] | :heavy_check_mark: | :heavy_check_mark: |  |  | V-HCAN |
+| [D-HCAN](./docs/source/models/hcan.rst)[ICDE 2025] | :heavy_check_mark: |  |  |  | 解耦版本 |
 | [HGDL](./docs/source/models/hgdl.rst)[NeurIPS 2024] | :heavy_check_mark: |  |  |  | v0.9新增 |
 | [HGEN](./docs/source/models/hgen.rst)[IJCAI 2025] | :heavy_check_mark: |  |  |  | v0.9新增 |
 | [HGSketch](./docs/source/models/hgsketch.rst)[SIGIR 2025] |  |  |  |  | v0.9新增，图级表示/graph classification pipeline |
@@ -400,7 +402,7 @@ python main.py -m MAGNN -d imdb4MAGNN -t node_classification -g 0 --use_best_con
 | --- | ---: | --- |
 | 新增模型贡献 | 10 | 按论文/模型贡献计数 |
 | 新增注册模型名 | 11 | `HERO` 和 `HERO_homo` 分别注册 |
-| 当前注册模型名 | 83 | 以 `openhgnn.models.SUPPORTED_MODELS` 为准 |
+| 当前注册模型名 | 86 | 以 `openhgnn.models.SUPPORTED_MODELS` 为准 |
 | 当前注册任务/流程入口 | 17 | 以 `openhgnn.tasks.SUPPORTED_TASKS` 为准 |
 
 v0.9新增模型贡献包括：HGDL、HGEN、HGSketch、HGOT、RMR、HERO/HERO_homo、SEHTGNN、HTGformer、HCMGNN、RelGT。

--- a/README_EN.md
+++ b/README_EN.md
@@ -25,7 +25,7 @@ of heterogeneous graph.
 We release OpenHGNN v0.9.
 
 - Added 10 model contributions, corresponding to 11 registered model names: HGDL, HGEN, HGSketch, HGOT, RMR, HERO/HERO_homo, SEHTGNN, HTGformer, HCMGNN, and RelGT.
-- The current version registers 83 model names and 17 task/flow entries.
+- The current version registers 86 model names and 17 task/flow entries.
 - Added the `node_regression` task for continuous node-label prediction.
 - Updated documentation entry points, quick start, model overview, task overview, and model PR checklist.
 - Strengthened model contribution standards around DGL implementation, trainerflow, dataset, README, and smoke-test requirements.
@@ -162,7 +162,7 @@ We released OpenHGNN v0.2.
 
 Current version statistics:
 
-- Registered model names: 83.
+- Registered model names: 86.
 - Registered task/flow entries: 17.
 - v0.9 model contributions: 10. `HERO` and `HERO_homo` are two registered names for one model contribution.
 - v0.9 task addition: `node_regression`.
@@ -347,7 +347,7 @@ python main.py -m MAGNN -d imdb4MAGNN -t node_classification -g 0 --use_best_con
 
 ### Supported Models with specific task
 
-The current version registers 83 model names. The table below tracks the main model-task coverage maintained in README. Use `openhgnn list models` for the complete registered model list.
+The current version registers 86 model names. The table below tracks the main model-task coverage maintained in README. Use `openhgnn list models` for the complete registered model list.
 
 | Model | Node classification | Link prediction | Recommendation | Node regression | Notes |
 | --- | --- | --- | --- | --- | --- |
@@ -383,6 +383,8 @@ The current version registers 83 model names. The table below tracks the main mo
 | [HetSANN](../openhgnn/output/HGT)[AAAI 2020] | :heavy_check_mark: |  |  |  |  |
 | [ieHGCN](../openhgnn/output/HGT)[TKDE 2021] | :heavy_check_mark: |  |  |  |  |
 | [KTN](../openhgnn/output/KTN)[NeurIPS 2022] | :heavy_check_mark: |  |  |  |  |
+| [HCAN](./docs/source/models/hcan.rst)[ICDE 2025] | :heavy_check_mark: | :heavy_check_mark: |  |  | V-HCAN |
+| [D-HCAN](./docs/source/models/hcan.rst)[ICDE 2025] | :heavy_check_mark: |  |  |  | Decoupled variant |
 | [HGDL](./docs/source/models/hgdl.rst)[NeurIPS 2024] | :heavy_check_mark: |  |  |  | v0.9 |
 | [HGEN](./docs/source/models/hgen.rst)[IJCAI 2025] | :heavy_check_mark: |  |  |  | v0.9 |
 | [HGSketch](./docs/source/models/hgsketch.rst)[SIGIR 2025] |  |  |  |  | v0.9, graph-level representation / graph classification pipeline |
@@ -401,7 +403,7 @@ The current version registers 83 model names. The table below tracks the main mo
 | --- | ---: | --- |
 | New model contributions | 10 | Counted by paper/model contribution |
 | New registered model names | 11 | `HERO` and `HERO_homo` are registered separately |
-| Current registered model names | 83 | Based on `openhgnn.models.SUPPORTED_MODELS` |
+| Current registered model names | 86 | Based on `openhgnn.models.SUPPORTED_MODELS` |
 | Current registered task/flow entries | 17 | Based on `openhgnn.tasks.SUPPORTED_TASKS` |
 
 v0.9 model contributions: HGDL, HGEN, HGSketch, HGOT, RMR, HERO/HERO_homo, SEHTGNN, HTGformer, HCMGNN, and RelGT.

--- a/docs/source/models/hcan.rst
+++ b/docs/source/models/hcan.rst
@@ -1,0 +1,63 @@
+HCAN
+====
+
+HCAN implements the two models proposed in *Effective and Scalable
+Heterogeneous Graph Neural Network Framework with Convolution-oriented
+Attention* (ICDE 2025): Vanilla HCAN (``HCAN``) and Decoupled HCAN
+(``DHCAN``, also registered as ``D-HCAN``).
+
+Model correspondence
+--------------------
+
+``HCAN`` follows Algorithm 1. Each layer builds the zero-to-``max_hop``
+convolutional tokens, computes relation-aware convolution-oriented attention,
+and combines the weighted and counterweight payloads.
+
+``DHCAN`` follows Equations 13--15. It enumerates only type-compatible
+relation paths, performs relation-wise mean propagation and non-parametric
+attention once without gradients, and caches those channel embeddings. The
+trainable channel projection and semantic fusion MLPs then reuse the cache at
+every epoch. Call ``model.clear_cache()`` before reusing a model with another
+graph or another feature set. ``cache_device`` controls where the precomputed
+channels are stored and defaults to ``cpu``. The dedicated node-classification
+trainer retains channels only for the target node type to limit host memory.
+
+Quick start
+-----------
+
+V-HCAN node classification on HGB ACM:
+
+.. code-block:: bash
+
+   python main.py -m HCAN -t node_classification -d HGBn-ACM -g 0
+
+D-HCAN node classification on OGB-MAG:
+
+.. code-block:: bash
+
+   python main.py -m DHCAN -t node_classification -d ogbn-mag -g 0
+
+The first D-HCAN forward pass includes precomputation. Report preprocessing
+time separately from training time per epoch when comparing with Table VIII.
+The paper reports five-run mean validation/test accuracy of 56.44/54.81 on
+OGB-MAG; reproducing that table requires five complete runs with the official
+temporal split. The complete OGB-MAG graph also requires substantial host
+memory during parameter-free precomputation.
+
+Configuration
+-------------
+
+The default options are in ``openhgnn/config.ini`` under ``[HCAN]`` and
+``[DHCAN]``. Both implementations consume the complete heterograph. The
+D-HCAN trainer performs its parameter-free graph propagation in full-batch
+mode on CPU, then trains cached target-node representations in batches.
+``hidden_dim`` must be divisible by ``2 * num_heads`` for V-HCAN because the
+weighted and counterweight payloads each produce half of the output, while
+D-HCAN uses a single decoupled propagation stage (``num_layers = 1``).
+
+Tests
+-----
+
+.. code-block:: bash
+
+   python -m pytest -o addopts= tests/test_hcan_model.py tests/test_hcan_config.py tests/test_node_classification_early_stop.py -q

--- a/docs/source/models/index.rst
+++ b/docs/source/models/index.rst
@@ -7,3 +7,4 @@ This section provides model-level documentation for OpenHGNN models.
    :maxdepth: 1
 
    hgot
+   hcan

--- a/openhgnn/config.ini
+++ b/openhgnn/config.ini
@@ -12,7 +12,35 @@ gamma = 0.0001
 mini_batch_flag = False
 evaluate_interval = 1
 
+[HCAN]
+hidden_dim = 64
+out_dim = 64
+num_layers = 1
+max_hop = 2
+num_heads = 4
+dropout = 0.3
+attn_activation = identity
+learning_rate = 0.001
+weight_decay = 0.0001
+max_epoch = 150
+patience = 40
+early_stop_metric = Micro_f1
+mini_batch_flag = False
 
+[DHCAN]
+hidden_dim = 64
+out_dim = 64
+num_layers = 1
+max_hop = 2
+dropout = 0.5
+learning_rate = 0.001
+weight_decay = 0.0001
+max_epoch = 100
+patience = 10
+cache_device = cpu
+cache_target_on_gpu = True
+batch_size = 65536
+mini_batch_flag = False
 
 [MHGCN]
 

--- a/openhgnn/config.py
+++ b/openhgnn/config.py
@@ -11,7 +11,7 @@ class Config(object):
     def __init__(self, file_path, model, dataset, task, gpu):
         conf = configparser.ConfigParser( )
         try:
-            conf.read(file_path)
+            conf.read(file_path, encoding="utf-8")
         except:
             print("failed!")
         # training dataset path
@@ -61,6 +61,55 @@ class Config(object):
             self.gamma = conf.getfloat('HGDL', 'gamma')
             self.mini_batch_flag = conf.getboolean('HGDL', 'mini_batch_flag')
             self.evaluate_interval = conf.getint('HGDL', 'evaluate_interval')
+
+        elif self.model_name == 'HCAN':
+            self.num_heads = conf.getint("HCAN", "num_heads")
+            self.hidden_dim = conf.getint("HCAN", "hidden_dim")
+            self.out_dim = conf.getint("HCAN", "out_dim")
+            self.num_layers = conf.getint("HCAN", "num_layers")
+            self.max_hop = conf.getint("HCAN", "max_hop")
+            self.dropout = conf.getfloat("HCAN", "dropout")
+            self.attn_activation = conf.get(
+                "HCAN", "attn_activation", fallback="identity"
+            )
+            self.lr = conf.getfloat(
+                "HCAN",
+                "learning_rate",
+                fallback=conf.getfloat("HCAN", "lr", fallback=0.001),
+            )
+            self.weight_decay = conf.getfloat("HCAN", "weight_decay")
+            self.max_epoch = conf.getint("HCAN", "max_epoch")
+            self.patience = conf.getint("HCAN", "patience")
+            self.early_stop_metric = conf.get(
+                "HCAN", "early_stop_metric", fallback="loss"
+            )
+            self.mini_batch_flag = conf.getboolean(
+                "HCAN", "mini_batch_flag", fallback=False
+            )
+
+        elif self.model_name in ['DHCAN', 'D-HCAN']:
+            self.hidden_dim = conf.getint("DHCAN", "hidden_dim")
+            self.out_dim = conf.getint("DHCAN", "out_dim")
+            self.num_layers = conf.getint("DHCAN", "num_layers")
+            self.max_hop = conf.getint("DHCAN", "max_hop")
+            self.dropout = conf.getfloat("DHCAN", "dropout")
+            self.lr = conf.getfloat(
+                "DHCAN",
+                "learning_rate",
+                fallback=conf.getfloat("DHCAN", "lr", fallback=0.001),
+            )
+            self.weight_decay = conf.getfloat("DHCAN", "weight_decay")
+            self.max_epoch = conf.getint("DHCAN", "max_epoch")
+            self.patience = conf.getint("DHCAN", "patience")
+            self.cache_device = conf.get("DHCAN", "cache_device", fallback="cpu")
+            self.cache_target_on_gpu = conf.getboolean(
+                "DHCAN", "cache_target_on_gpu", fallback=True
+            )
+            self.batch_size = conf.getint("DHCAN", "batch_size", fallback=65536)
+            self.mini_batch_flag = conf.getboolean(
+                "DHCAN", "mini_batch_flag", fallback=False
+            )
+
         elif self.model_name == 'MHGCN':
             self.lr = conf.getfloat("MHGCN", "lr")
             self.weight_decay = conf.getfloat("MHGCN", "weight_decay")

--- a/openhgnn/dataset/NodeClassificationDataset.py
+++ b/openhgnn/dataset/NodeClassificationDataset.py
@@ -1023,7 +1023,10 @@ class OGB_NodeClassification(NodeClassificationDataset):
         self.train_idx, self.valid_idx, self.test_idx = split_idx["train"][self.category], split_idx["valid"][
             self.category], split_idx["test"][self.category]
         self.g, self.label_dict = dataset[0]
-        self.SeHGNN_g = self.mag4sehgnn(dataset)
+        model_name = getattr(kwargs.get('args'), 'model_name', None)
+        self.SeHGNN_g = (
+            self.mag4sehgnn(dataset) if model_name == 'SeHGNN' else None
+        )
         self.g = self.mag4HGT(self.g)
         self.label = self.label_dict[self.category].squeeze(dim=-1)
         # 2-dim label

--- a/openhgnn/experiment.py
+++ b/openhgnn/experiment.py
@@ -69,6 +69,8 @@ class Experiment(object):
         'lightGCN': 'lightGCN_trainer',
         'HMPNN':'KTN_trainer',
         'SeHGNN': 'SeHGNN_trainer',
+        'DHCAN': 'dhcan_trainer',
+        'D-HCAN': 'dhcan_trainer',
         'Grail': 'Grail_trainer',
         'ComPILE': 'ComPILE_trainer',
         'AdapropT':'AdapropT_trainer',

--- a/openhgnn/models/HCAN.py
+++ b/openhgnn/models/HCAN.py
@@ -1,0 +1,751 @@
+"""
+Heterogeneous Convolution-oriented Attention Network (HCAN).
+
+This module implements Vanilla HCAN (V-HCAN) and Decoupled HCAN (D-HCAN) from
+"Effective and Scalable Heterogeneous Graph Neural Network Framework
+with Convolution-oriented Attention".
+"""
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from dgl import function as fn
+from dgl.ops import edge_softmax
+
+from . import BaseModel, register_model
+
+
+@register_model("HCAN")
+class HCAN(BaseModel):
+    r"""Vanilla HCAN.
+
+    The model follows Algorithm 1 in the paper. For node classification,
+    ``forward`` returns decoded logits. For representation-learning tasks
+    such as link prediction, it returns node embeddings and lets the
+    trainerflow provide the task-specific decoder.
+    """
+
+    @classmethod
+    def build_model_from_args(cls, args, hg):
+        task = getattr(args, "task", None)
+        use_decoder = getattr(args, "use_decoder", task == "node_classification")
+        hidden_dim = getattr(args, "hidden_dim", 64)
+        out_dim = getattr(args, "out_dim", hidden_dim)
+        if not use_decoder:
+            out_dim = hidden_dim
+            args.out_dim = hidden_dim
+        return cls(
+            hidden_dim=hidden_dim,
+            out_dim=out_dim,
+            num_layers=getattr(args, "num_layers", 1),
+            max_hop=getattr(args, "max_hop", 2),
+            num_heads=getattr(args, "num_heads", 4),
+            ntypes=hg.ntypes,
+            etypes=hg.canonical_etypes,
+            dropout=getattr(args, "dropout", 0.5),
+            use_decoder=use_decoder,
+            attn_activation=getattr(args, "attn_activation", "identity"),
+        )
+
+    def __init__(
+        self,
+        hidden_dim,
+        out_dim,
+        num_layers,
+        max_hop,
+        num_heads,
+        ntypes,
+        etypes,
+        dropout,
+        use_decoder=True,
+        attn_activation="identity",
+    ):
+        super(HCAN, self).__init__()
+        if hidden_dim % (2 * num_heads) != 0:
+            raise ValueError(
+                "hidden_dim ({}) must be divisible by twice num_heads ({})".format(
+                    hidden_dim, 2 * num_heads
+                )
+            )
+
+        self.hidden_dim = hidden_dim
+        self.out_dim = out_dim if use_decoder else hidden_dim
+        self.emb_dim = hidden_dim
+        self.num_layers = num_layers
+        self.max_hop = max_hop
+        self.num_heads = num_heads
+        self.ntypes = list(ntypes)
+        self.etypes = list(etypes)
+        self.use_decoder = use_decoder
+
+        self.layers = nn.ModuleList(
+            [
+                VHCANLayer(
+                    hidden_dim=hidden_dim,
+                    max_hop=max_hop,
+                    num_heads=num_heads,
+                    ntypes=self.ntypes,
+                    etypes=self.etypes,
+                    dropout=dropout,
+                    attn_activation=attn_activation,
+                )
+                for _ in range(num_layers)
+            ]
+        )
+        self.decoder = (
+            nn.Linear(hidden_dim, out_dim, bias=False) if use_decoder else None
+        )
+
+    def encode(self, hg, h_dict):
+        if not hasattr(hg, "ntypes"):
+            raise NotImplementedError(
+                "HCAN currently supports full-batch heterographs."
+            )
+        for layer in self.layers:
+            h_dict = layer(hg, h_dict)
+        return h_dict
+
+    def forward(self, hg, h_dict, return_emb=False):
+        h_dict = self.encode(hg, h_dict)
+        if return_emb or self.decoder is None:
+            return h_dict
+        return {ntype: self.decoder(h) for ntype, h in h_dict.items()}
+
+    def get_emb(self, hg, h_dict):
+        return {
+            ntype: h.detach().cpu().numpy()
+            for ntype, h in self.encode(hg, h_dict).items()
+        }
+
+
+class VHCANLayer(nn.Module):
+    r"""One V-HCAN layer with convolution-oriented attention."""
+
+    def __init__(
+        self,
+        hidden_dim,
+        max_hop,
+        num_heads,
+        ntypes,
+        etypes,
+        dropout,
+        attn_activation="identity",
+    ):
+        super(VHCANLayer, self).__init__()
+        self.hidden_dim = hidden_dim
+        self.max_hop = max_hop
+        self.num_heads = num_heads
+        self.head_dim = hidden_dim // num_heads
+        self.value_head_dim = hidden_dim // (2 * num_heads)
+        self.ntypes = list(ntypes)
+        self.etypes = list(etypes)
+        self.etype_keys = {etype: str(idx) for idx, etype in enumerate(self.etypes)}
+        self.enhanced_dim = hidden_dim * (max_hop + 1)
+        self.attn_activation = attn_activation.lower()
+        if self.attn_activation not in {"identity", "leaky_relu", "relu"}:
+            raise ValueError(
+                "Unsupported HCAN attention activation: {}".format(attn_activation)
+            )
+
+        self.proj_mlp = nn.ModuleDict(
+            {
+                ntype: nn.Sequential(nn.Linear(hidden_dim, hidden_dim), nn.PReLU())
+                for ntype in self.ntypes
+            }
+        )
+        self.hop_mlp = nn.ModuleDict(
+            {
+                ntype: nn.Sequential(
+                    nn.Linear(hidden_dim, hidden_dim), nn.PReLU()
+                )
+                for ntype in self.ntypes
+            }
+        )
+
+        self.hat_norm = nn.ModuleDict(
+            {ntype: nn.LayerNorm(self.enhanced_dim) for ntype in self.ntypes}
+        )
+        self.hat_act = nn.PReLU()
+        self.attn_Q = nn.ParameterDict(
+            {
+                ntype: nn.Parameter(
+                    torch.empty(num_heads, self.enhanced_dim, self.head_dim)
+                )
+                for ntype in self.ntypes
+            }
+        )
+        self.attn_K = nn.ParameterDict(
+            {
+                ntype: nn.Parameter(
+                    torch.empty(num_heads, self.enhanced_dim, self.head_dim)
+                )
+                for ntype in self.ntypes
+            }
+        )
+        self.attn_a = nn.ParameterDict(
+            {
+                key: nn.Parameter(torch.empty(num_heads, 2 * self.head_dim))
+                for key in self.etype_keys.values()
+            }
+        )
+        self.value_V = nn.ParameterDict(
+            {
+                key: nn.Parameter(
+                    torch.empty(num_heads, self.enhanced_dim, self.value_head_dim)
+                )
+                for key in self.etype_keys.values()
+            }
+        )
+        self.residual_W = nn.ModuleDict(
+            {
+                ntype: nn.Linear(self.enhanced_dim, hidden_dim, bias=True)
+                for ntype in self.ntypes
+            }
+        )
+        self.act = nn.PReLU()
+        self.norm = nn.ModuleDict(
+            {ntype: nn.LayerNorm(hidden_dim) for ntype in self.ntypes}
+        )
+        self.dropout = nn.Dropout(dropout)
+        self._reset_parameters()
+
+    def _reset_parameters(self):
+        for ntype in self.ntypes:
+            for head in range(self.num_heads):
+                nn.init.xavier_uniform_(self.attn_Q[ntype][head])
+                nn.init.xavier_uniform_(self.attn_K[ntype][head])
+        for key in self.etype_keys.values():
+            nn.init.xavier_uniform_(self.attn_a[key])
+            for head in range(self.num_heads):
+                nn.init.xavier_uniform_(self.value_V[key][head])
+
+    def _activate_attention(self, score):
+        if self.attn_activation == "identity":
+            return score
+        if self.attn_activation == "relu":
+            return F.relu(score)
+        return F.leaky_relu(score, negative_slope=0.2)
+
+    def _etype_key(self, etype):
+        return self.etype_keys[etype]
+
+    def _compute_attn_score(self, edges, etype):
+        src_t, _, dst_t = etype
+        q = torch.einsum("ei,hid->ehd", edges.dst["h_hat"], self.attn_Q[dst_t])
+        k = torch.einsum("ei,hid->ehd", edges.src["h_hat"], self.attn_K[src_t])
+        qk = torch.cat([q, k], dim=-1)
+        etype_key = self._etype_key(etype)
+        score = (qk * self.attn_a[etype_key].unsqueeze(0)).sum(dim=-1)
+        return {"attn_score": self._activate_attention(score).unsqueeze(-1)}
+
+    def _all_relation_mean_propagation(self, hg, h_dict):
+        with hg.local_scope():
+            for ntype in self.ntypes:
+                hg.nodes[ntype].data["h"] = h_dict[ntype]
+
+            hg.multi_update_all(
+                {
+                    etype: (fn.copy_u("h", "m"), fn.sum("m", "h_sum"))
+                    for etype in self.etypes
+                },
+                cross_reducer="sum",
+            )
+
+            next_h = {}
+            for ntype in self.ntypes:
+                if "h_sum" in hg.nodes[ntype].data:
+                    h_sum = hg.nodes[ntype].data["h_sum"]
+                else:
+                    h_sum = torch.zeros_like(h_dict[ntype])
+
+                degree = torch.zeros(
+                    hg.num_nodes(ntype), device=h_sum.device, dtype=h_sum.dtype
+                )
+                for etype in self.etypes:
+                    if etype[2] == ntype:
+                        degree = degree + hg.in_degrees(etype=etype).to(
+                            device=h_sum.device, dtype=h_sum.dtype
+                        )
+                next_h[ntype] = h_sum / degree.clamp(min=1).unsqueeze(-1)
+            return next_h
+
+    def _edge_softmax_by_head(self, g, scores):
+        gamma = []
+        for head in range(self.num_heads):
+            gamma.append(edge_softmax(g, scores[:, head, :]))
+        return torch.stack(gamma, dim=1)
+
+    def forward(self, hg, h_dict):
+        h_proj = {
+            ntype: self.proj_mlp[ntype](h_dict[ntype])
+            for ntype in self.ntypes
+        }
+
+        raw_tokens = [h_proj]
+        current = h_proj
+        for _ in range(self.max_hop):
+            current = self._all_relation_mean_propagation(hg, current)
+            raw_tokens.append(current)
+
+        refined_tokens = [h_proj]
+        for hop in range(1, self.max_hop + 1):
+            refined_tokens.append(
+                {
+                    ntype: self.hop_mlp[ntype](raw_tokens[hop][ntype])
+                    for ntype in self.ntypes
+                }
+            )
+
+        h_hat = {}
+        for ntype in self.ntypes:
+            h_hat[ntype] = torch.cat(
+                [refined_tokens[hop][ntype] for hop in range(self.max_hop + 1)],
+                dim=-1,
+            )
+            h_hat[ntype] = self.hat_act(
+                self.dropout(self.hat_norm[ntype](h_hat[ntype]))
+            )
+
+        with hg.local_scope():
+            for ntype in self.ntypes:
+                hg.nodes[ntype].data["h_hat"] = h_hat[ntype]
+
+            h_high = {
+                ntype: h_hat[ntype].new_zeros(
+                    hg.num_nodes(ntype), self.hidden_dim // 2
+                )
+                for ntype in self.ntypes
+            }
+            h_low = {
+                ntype: h_hat[ntype].new_zeros(
+                    hg.num_nodes(ntype), self.hidden_dim // 2
+                )
+                for ntype in self.ntypes
+            }
+
+            for etype in self.etypes:
+                if hg.num_edges(etype) == 0:
+                    continue
+
+                src_t, _, dst_t = etype
+                etype_key = self._etype_key(etype)
+                hg[etype].apply_edges(
+                    lambda edges, e=etype: self._compute_attn_score(edges, e)
+                )
+
+                gamma = self._edge_softmax_by_head(
+                    hg[etype], hg[etype].edata["attn_score"]
+                )
+                gamma_tilde = 1.0 - gamma
+
+                value = torch.einsum(
+                    "ni,hid->nhd",
+                    hg.nodes[src_t].data["h_hat"],
+                    self.value_V[etype_key],
+                )
+                hg.nodes[src_t].data["v"] = value
+
+                hg[etype].edata["gamma"] = gamma
+                hg.update_all(
+                    fn.u_mul_e("v", "gamma", "m_high"),
+                    fn.sum("m_high", "agg_high"),
+                    etype=etype,
+                )
+                hg[etype].edata["gamma_tilde"] = gamma_tilde
+                hg.update_all(
+                    fn.u_mul_e("v", "gamma_tilde", "m_low"),
+                    fn.sum("m_low", "agg_low"),
+                    etype=etype,
+                )
+
+                h_high[dst_t] = h_high[dst_t] + hg.nodes[dst_t].data[
+                    "agg_high"
+                ].reshape(hg.num_nodes(dst_t), -1)
+                h_low[dst_t] = h_low[dst_t] + hg.nodes[dst_t].data[
+                    "agg_low"
+                ].reshape(hg.num_nodes(dst_t), -1)
+
+            h_out = {}
+            for ntype in self.ntypes:
+                combined = torch.cat([h_high[ntype], h_low[ntype]], dim=-1)
+                out = self.act(combined + self.residual_W[ntype](h_hat[ntype]))
+                h_out[ntype] = self.norm[ntype](out)
+            return h_out
+
+
+@register_model("D-HCAN")
+@register_model("DHCAN")
+class DHCAN(BaseModel):
+    r"""Decoupled HCAN.
+
+    D-HCAN decouples feature projection from K-hop subgraph convolution.
+    It first generates edge-type-specific K-hop tokens without trainable
+    parameters, then computes non-parametric attention weights for each
+    token channel and fuses the resulting embeddings with feed-forward
+    networks.
+    """
+
+    @classmethod
+    def build_model_from_args(cls, args, hg):
+        task = getattr(args, "task", None)
+        use_decoder = getattr(args, "use_decoder", task == "node_classification")
+        hidden_dim = getattr(args, "hidden_dim", 64)
+        out_dim = getattr(args, "out_dim", hidden_dim)
+        if not use_decoder:
+            out_dim = hidden_dim
+            args.out_dim = hidden_dim
+        return cls(
+            hidden_dim=hidden_dim,
+            token_dim=getattr(args, "dhcan_input_dim", hidden_dim),
+            out_dim=out_dim,
+            num_layers=getattr(args, "num_layers", 1),
+            max_hop=getattr(args, "max_hop", 2),
+            ntypes=hg.ntypes,
+            etypes=hg.canonical_etypes,
+            dropout=getattr(args, "dropout", 0.5),
+            use_decoder=use_decoder,
+            cache_device=getattr(args, "cache_device", "cpu"),
+        )
+
+    def __init__(
+        self,
+        hidden_dim,
+        token_dim,
+        out_dim,
+        num_layers,
+        max_hop,
+        ntypes,
+        etypes,
+        dropout,
+        use_decoder=True,
+        cache_device="cpu",
+    ):
+        super(DHCAN, self).__init__()
+        if num_layers != 1:
+            raise ValueError(
+                "D-HCAN uses one decoupled propagation stage; num_layers must be 1."
+            )
+        self.hidden_dim = hidden_dim
+        self.token_dim = token_dim
+        self.out_dim = out_dim if use_decoder else hidden_dim
+        self.emb_dim = hidden_dim
+        self.num_layers = num_layers
+        self.max_hop = max_hop
+        self.ntypes = list(ntypes)
+        self.etypes = list(etypes)
+        self.use_decoder = use_decoder
+        self.cache_device = torch.device(cache_device)
+        self.layers = nn.ModuleList(
+            [
+                DHCANLayer(
+                    hidden_dim=hidden_dim,
+                    token_dim=token_dim,
+                    max_hop=max_hop,
+                    ntypes=self.ntypes,
+                    etypes=self.etypes,
+                    dropout=dropout,
+                    cache_device=self.cache_device,
+                )
+                for _ in range(num_layers)
+            ]
+        )
+        self.decoder = (
+            nn.Linear(hidden_dim, out_dim, bias=False) if use_decoder else None
+        )
+
+    def encode(self, hg, h_dict):
+        if not hasattr(hg, "ntypes"):
+            raise NotImplementedError(
+                "DHCAN currently supports full-batch heterographs."
+            )
+        for layer in self.layers:
+            h_dict = layer(hg, h_dict)
+        return h_dict
+
+    def clear_cache(self):
+        """Discard non-parametric propagation results before using new inputs."""
+        for layer in self.layers:
+            layer.clear_cache()
+
+    def precompute(self, hg, h_dict, target_ntype=None):
+        """Precompute parameter-free channels, optionally for one node type."""
+        return self.layers[0].precompute(hg, h_dict, target_ntype)
+
+    def move_cached_type(self, ntype, device):
+        """Move only one output node type's cached channels to ``device``."""
+        self.layers[0].move_cached_type(ntype, device)
+
+    def forward_cached(self, ntype, node_idx=None):
+        """Decode cached representations for one node type or node batch."""
+        device = next(self.parameters()).device
+        embedding = self.layers[0].fuse_cached(ntype, node_idx, device)
+        return self.decoder(embedding) if self.decoder is not None else embedding
+
+    def forward(self, hg, h_dict, return_emb=False):
+        h_dict = self.encode(hg, h_dict)
+        if return_emb or self.decoder is None:
+            return h_dict
+        return {ntype: self.decoder(h) for ntype, h in h_dict.items()}
+
+    def get_emb(self, hg, h_dict):
+        return {
+            ntype: h.detach().cpu().numpy()
+            for ntype, h in self.encode(hg, h_dict).items()
+        }
+
+
+class DHCANLayer(nn.Module):
+    r"""One D-HCAN layer following Equations 13-15."""
+
+    def __init__(
+        self,
+        hidden_dim,
+        token_dim,
+        max_hop,
+        ntypes,
+        etypes,
+        dropout,
+        cache_device="cpu",
+    ):
+        super(DHCANLayer, self).__init__()
+        if max_hop < 1:
+            raise ValueError("D-HCAN max_hop must be at least 1.")
+        self.hidden_dim = hidden_dim
+        self.token_dim = token_dim
+        self.max_hop = max_hop
+        self.ntypes = list(ntypes)
+        self.etypes = list(etypes)
+        self.cache_device = torch.device(cache_device)
+        self.relation_paths = self._enumerate_relation_paths()
+        self.num_channels = len(self.relation_paths)
+        if self.num_channels == 0:
+            raise ValueError(
+                "D-HCAN found no valid relation path for max_hop={}.".format(
+                    max_hop
+                )
+            )
+        self._cached_tokens = None
+
+        self.channel_proj = nn.ModuleDict(
+            {
+                ntype: nn.ModuleList(
+                    [
+                        nn.Sequential(
+                            nn.Linear(token_dim, hidden_dim),
+                            nn.PReLU(),
+                            nn.Dropout(dropout),
+                        )
+                        for _ in range(self.num_channels)
+                    ]
+                )
+                for ntype in self.ntypes
+            }
+        )
+        self.semantic_fusion = nn.ModuleDict(
+            {
+                ntype: nn.Sequential(
+                    nn.Linear(self.num_channels * hidden_dim, hidden_dim),
+                    nn.PReLU(),
+                    nn.Dropout(dropout),
+                )
+                for ntype in self.ntypes
+            }
+        )
+
+    def _enumerate_relation_paths(self):
+        paths = [(etype,) for etype in self.etypes]
+        for _ in range(1, self.max_hop):
+            paths = [
+                path + (etype,)
+                for path in paths
+                for etype in self.etypes
+                if path[-1][2] == etype[0]
+            ]
+        return paths
+
+    def _relation_propagate(self, hg, features, etype):
+        src_t, _, dst_t = etype
+        if hg.num_edges(etype) == 0:
+            return features.new_zeros(hg.num_nodes(dst_t), features.shape[-1])
+
+        with hg.local_scope():
+            hg.nodes[src_t].data["h"] = features
+            hg.update_all(
+                fn.copy_u("h", "m"),
+                fn.mean("m", "h_mean"),
+                etype=etype,
+            )
+            return hg.nodes[dst_t].data["h_mean"]
+
+    def _generate_decoupled_tokens(self, hg, h_dict):
+        def expand(path, features):
+            if len(path) == self.max_hop:
+                yield path[-1][2], features
+                return
+
+            for etype in self.etypes:
+                if path[-1][2] != etype[0]:
+                    continue
+                next_features = self._relation_propagate(hg, features, etype)
+                yield from expand(path + (etype,), next_features)
+
+        for etype in self.etypes:
+            features = self._relation_propagate(hg, h_dict[etype[0]], etype)
+            yield from expand((etype,), features)
+
+    def _safe_divide(self, numerator, denominator):
+        valid = denominator.abs() > 1e-12
+        safe_denominator = torch.where(
+            valid, denominator, torch.ones_like(denominator)
+        )
+        return torch.where(
+            valid, numerator / safe_denominator, torch.zeros_like(numerator)
+        )
+
+    def _non_parametric_attention(self, hg, h_dict, token, target_ntype=None):
+        token_type, token_features = token
+        reachable_types = {token_type}
+        reachable_types.update(
+            etype[2]
+            for etype in self.etypes
+            if etype[0] == token_type and hg.num_edges(etype) > 0
+        )
+        if target_ntype is not None:
+            if target_ntype not in reachable_types:
+                return {}
+            output_types = {target_ntype}
+        else:
+            output_types = reachable_types
+        numerator = {
+            ntype: h_dict[ntype].new_zeros(hg.num_nodes(ntype), self.token_dim)
+            for ntype in output_types
+        }
+        denominator = {
+            ntype: h_dict[ntype].new_zeros(hg.num_nodes(ntype), 1)
+            for ntype in output_types
+        }
+        with hg.local_scope():
+            for ntype in self.ntypes:
+                hg.nodes[ntype].data["base"] = h_dict[ntype]
+            hg.nodes[token_type].data["token"] = token_features
+
+            if token_type in output_types:
+                self_score = (h_dict[token_type] * token_features).sum(
+                    dim=-1, keepdim=True
+                )
+                denominator[token_type] = denominator[token_type] + self_score
+                numerator[token_type] = (
+                    numerator[token_type] + token_features * self_score
+                )
+
+            for etype in self.etypes:
+                if (
+                    etype[0] != token_type
+                    or etype[2] not in output_types
+                    or hg.num_edges(etype) == 0
+                ):
+                    continue
+                _, _, dst_t = etype
+                hg[etype].apply_edges(
+                    lambda edges: {
+                        "score": (edges.dst["base"] * edges.src["token"]).sum(
+                            dim=-1, keepdim=True
+                        )
+                    }
+                )
+                hg.update_all(
+                    fn.copy_e("score", "m_score"),
+                    fn.sum("m_score", "score_sum"),
+                    etype=etype,
+                )
+                hg.update_all(
+                    fn.u_mul_e("token", "score", "m_token"),
+                    fn.sum("m_token", "token_sum"),
+                    etype=etype,
+                )
+                denominator[dst_t] = denominator[dst_t] + hg.nodes[dst_t].data[
+                    "score_sum"
+                ]
+                numerator[dst_t] = numerator[dst_t] + hg.nodes[dst_t].data[
+                    "token_sum"
+                ]
+
+        return {
+            ntype: self._safe_divide(numerator[ntype], denominator[ntype])
+            for ntype in output_types
+        }
+
+    def clear_cache(self):
+        self._cached_tokens = None
+
+    def move_cached_type(self, ntype, device):
+        if self._cached_tokens is None:
+            raise RuntimeError(
+                "D-HCAN channels must be precomputed before moving them."
+            )
+        device = torch.device(device)
+        for token in self._cached_tokens:
+            if ntype in token:
+                token[ntype] = token[ntype].to(device)
+
+    @torch.no_grad()
+    def precompute(self, hg, h_dict, target_ntype=None):
+        """Run Equations 13-15 once and cache parameter-free outputs."""
+        if target_ntype is not None and target_ntype not in self.ntypes:
+            raise ValueError("Unknown D-HCAN target node type: {}".format(target_ntype))
+        self._cached_tokens = [
+            {
+                ntype: value.detach().to(self.cache_device)
+                for ntype, value in self._non_parametric_attention(
+                    hg, h_dict, token, target_ntype
+                ).items()
+            }
+            for token in self._generate_decoupled_tokens(hg, h_dict)
+        ]
+        return self._cached_tokens
+
+    def fuse_cached(self, ntype, node_idx, device):
+        if self._cached_tokens is None:
+            raise RuntimeError("D-HCAN channels have not been precomputed.")
+        fusion_linear = self.semantic_fusion[ntype][0]
+        if node_idx is None:
+            num_nodes = next(
+                token[ntype].shape[0]
+                for token in self._cached_tokens
+                if ntype in token
+            )
+        else:
+            num_nodes = node_idx.shape[0]
+        fused = fusion_linear.bias.unsqueeze(0).expand(num_nodes, -1)
+        for channel, token in enumerate(self._cached_tokens):
+            if ntype not in token:
+                continue
+            token_features = token[ntype]
+            if node_idx is not None:
+                token_features = token_features.index_select(
+                    0, node_idx.to(token_features.device)
+                )
+            token_features = token_features.to(device)
+            mask = token_features.abs().sum(dim=-1, keepdim=True) > 0
+            projected_token = self.channel_proj[ntype][channel](token_features)
+            projected_token = projected_token * mask.to(projected_token.dtype)
+            start = channel * self.hidden_dim
+            stop = start + self.hidden_dim
+            fused = fused + F.linear(
+                projected_token, fusion_linear.weight[:, start:stop]
+            )
+        fused = self.semantic_fusion[ntype][1](fused)
+        return self.semantic_fusion[ntype][2](fused)
+
+    def forward(self, hg, h_dict):
+        if self._cached_tokens is None:
+            self.precompute(hg, h_dict)
+
+        out_dict = {}
+        for ntype in self.ntypes:
+            out_dict[ntype] = self.fuse_cached(
+                ntype=ntype,
+                node_idx=None,
+                device=h_dict[ntype].device,
+            )
+        return out_dict

--- a/openhgnn/models/__init__.py
+++ b/openhgnn/models/__init__.py
@@ -69,6 +69,9 @@ SUPPORTED_MODELS = {
     'HGDL':'openhgnn.models.HGDL',
     'MHGCN':'openhgnn.models.MHGCN',
     'BPHGNN' : 'openhgnn.models.BPHGNN',
+    'HCAN': 'openhgnn.models.HCAN',
+    'DHCAN': 'openhgnn.models.HCAN',
+    'D-HCAN': 'openhgnn.models.HCAN',
     "MetaHIN": "openhgnn.models.MetaHIN",
     'HGA':'openhgnn.models.HGA',
     'RHINE': 'openhgnn.models.RHINE',
@@ -220,6 +223,7 @@ from .HERO_homo import HEROHomo
 
 from .RMR import RMR
 from .HGOT import HGOT
+from .HCAN import HCAN, DHCAN
 
 
 __all__ = [
@@ -227,6 +231,8 @@ __all__ = [
     'BPHGNN',
     "HMPNN",
     'BaseModel',
+    'HCAN',
+    'DHCAN',
     'CompGCN',
     'HetGNN',
     'RGCN',

--- a/openhgnn/trainerflow/__init__.py
+++ b/openhgnn/trainerflow/__init__.py
@@ -64,6 +64,7 @@ SUPPORTED_FLOWS = {
     'SIAN_trainer': 'openhgnn.trainerflow.SIAN_trainer',
     'entity_classification': 'openhgnn.trainerflow.entity_classification',
     'node_classification': 'openhgnn.trainerflow.node_classification',
+    'dhcan_trainer': 'openhgnn.trainerflow.dhcan_trainer',
     'node_classification_ac': 'openhgnn.trainerflow.node_classfication_ac',
     'distmult': 'openhgnn.trainerflow.dist_mult',
     'link_prediction': 'openhgnn.trainerflow.link_prediction',

--- a/openhgnn/trainerflow/dhcan_trainer.py
+++ b/openhgnn/trainerflow/dhcan_trainer.py
@@ -1,0 +1,162 @@
+import copy
+import time
+
+import torch
+from torch.utils.data import DataLoader
+
+from ..models import build_model
+from . import BaseFlow, register_flow
+
+
+@register_flow("dhcan_trainer")
+class DHCANTrainer(BaseFlow):
+    r"""Target-node mini-batch trainer for decoupled HCAN.
+
+    Equations 13-15 are precomputed once on CPU. Only the cached channels for
+    the classification node type are kept on GPU during iterative training.
+    """
+
+    def __init__(self, args):
+        if args.task != "node_classification":
+            raise ValueError(
+                "The D-HCAN trainer currently supports node classification only."
+            )
+        args.use_uva = True
+        super(DHCANTrainer, self).__init__(args)
+
+        self.category = self.task.dataset.category
+        self.num_classes = self.task.dataset.num_classes
+        self.train_idx, self.val_idx, self.test_idx = self.task.get_split()
+        self.labels = self.task.get_labels().long().cpu()
+
+        h_dict = self.hg.ndata.get("h", {})
+        if not isinstance(h_dict, dict) or set(h_dict) != set(self.hg.ntypes):
+            raise ValueError(
+                "D-HCAN requires an input feature tensor for every node type."
+            )
+        feature_dims = {features.shape[1] for features in h_dict.values()}
+        if len(feature_dims) != 1:
+            raise ValueError(
+                "D-HCAN attention requires equal feature dimensions across node types."
+            )
+        self.h_dict = {
+            ntype: features.detach().cpu() for ntype, features in h_dict.items()
+        }
+
+        args.dhcan_input_dim = feature_dims.pop()
+        args.out_dim = self.num_classes
+        self.model = build_model(self.model).build_model_from_args(
+            args, self.hg
+        ).to(self.device)
+        self.optimizer = self.candidate_optimizer[args.optimizer](
+            self.model.parameters(), lr=args.lr, weight_decay=args.weight_decay
+        )
+        self.loss_fn = self.task.get_loss_fn()
+        self.batch_size = getattr(args, "batch_size", 65536)
+        self.cache_target_on_gpu = getattr(args, "cache_target_on_gpu", True)
+
+    def _loader(self, node_idx, shuffle=False):
+        return DataLoader(
+            node_idx.cpu(),
+            batch_size=self.batch_size,
+            shuffle=shuffle,
+            pin_memory=torch.cuda.is_available(),
+        )
+
+    def _train_epoch(self):
+        self.model.train()
+        total_loss = 0.0
+        total_nodes = 0
+        for node_idx in self._loader(self.train_idx, shuffle=True):
+            logits = self.model.forward_cached(self.category, node_idx)
+            labels = self.labels[node_idx].to(self.device, non_blocking=True)
+            loss = self.loss_fn(logits, labels)
+
+            self.optimizer.zero_grad()
+            loss.backward()
+            self.optimizer.step()
+
+            total_loss += loss.item() * node_idx.numel()
+            total_nodes += node_idx.numel()
+        return total_loss / total_nodes
+
+    @torch.no_grad()
+    def _evaluate(self, node_idx):
+        self.model.eval()
+        total_loss = 0.0
+        total_correct = 0
+        total_nodes = 0
+        for batch_idx in self._loader(node_idx):
+            logits = self.model.forward_cached(self.category, batch_idx)
+            labels = self.labels[batch_idx].to(self.device, non_blocking=True)
+            total_loss += self.loss_fn(logits, labels).item() * batch_idx.numel()
+            total_correct += (logits.argmax(dim=-1) == labels).sum().item()
+            total_nodes += batch_idx.numel()
+        return total_loss / total_nodes, total_correct / total_nodes
+
+    def train(self):
+        precompute_start = time.perf_counter()
+        self.logger.info("[D-HCAN] Precomputing parameter-free channels on CPU.")
+        self.model.precompute(
+            self.hg, self.h_dict, target_ntype=self.category
+        )
+        if self.cache_target_on_gpu:
+            self.model.move_cached_type(self.category, self.device)
+        precompute_seconds = time.perf_counter() - precompute_start
+        self.logger.info(
+            "[D-HCAN] Precomputation finished in {:.2f}s.".format(
+                precompute_seconds
+            )
+        )
+
+        best_epoch = -1
+        best_val_accuracy = float("-inf")
+        best_state = None
+        stale_epochs = 0
+        epoch_times = []
+
+        for epoch in range(self.max_epoch):
+            epoch_start = time.perf_counter()
+            train_loss = self._train_epoch()
+            epoch_seconds = time.perf_counter() - epoch_start
+            epoch_times.append(epoch_seconds)
+            val_loss, val_accuracy = self._evaluate(self.val_idx)
+            self.logger.info(
+                "Epoch: {}, Train loss: {:.4f}, Valid loss: {:.4f}, "
+                "Valid accuracy: {:.4f}, Time: {:.2f}s".format(
+                    epoch,
+                    train_loss,
+                    val_loss,
+                    val_accuracy,
+                    epoch_seconds,
+                )
+            )
+
+            if val_accuracy >= best_val_accuracy:
+                best_epoch = epoch
+                best_val_accuracy = val_accuracy
+                best_state = copy.deepcopy(self.model.state_dict())
+                stale_epochs = 0
+            else:
+                stale_epochs += 1
+                if stale_epochs >= self.patience:
+                    break
+
+        self.model.load_state_dict(best_state)
+        val_loss, val_accuracy = self._evaluate(self.val_idx)
+        metric = {"valid": {"Accuracy": val_accuracy}}
+        if self.args.test_flag:
+            test_loss, test_accuracy = self._evaluate(self.test_idx)
+            metric["test"] = {"Accuracy": test_accuracy}
+            self.logger.info(
+                "[Test Info] Valid accuracy: {:.4f}, Test accuracy: {:.4f}".format(
+                    val_accuracy, test_accuracy
+                )
+            )
+
+        return {
+            "metric": metric,
+            "epoch": best_epoch,
+            "precompute_seconds": precompute_seconds,
+            "mean_epoch_seconds": sum(epoch_times) / len(epoch_times),
+        }

--- a/openhgnn/trainerflow/node_classification.py
+++ b/openhgnn/trainerflow/node_classification.py
@@ -196,6 +196,35 @@ class NodeClassification(BaseFlow):
 
         super(NodeClassification, self).preprocess()
 
+    def _early_stop_step(self, stopper, val_loss, valid_metric):
+        early_stop_metric = getattr(self.args, 'early_stop_metric', 'loss')
+        if early_stop_metric is None:
+            early_stop_metric = 'loss'
+        early_stop_metric = str(early_stop_metric)
+        if early_stop_metric.lower() == 'loss':
+            return stopper.loss_step(val_loss, self.model)
+
+        if early_stop_metric.lower() == 'f1':
+            metric_candidates = ['Micro_f1', 'Macro_f1']
+        else:
+            metric_candidates = [early_stop_metric]
+
+        score = None
+        for metric_name in metric_candidates:
+            for key, value in valid_metric.items():
+                if key.lower() == metric_name.lower():
+                    score = value
+                    break
+            if score is not None:
+                break
+        if score is None:
+            raise ValueError(
+                'early_stop_metric={} is not found in validation metrics {}.'.format(
+                    early_stop_metric, list(valid_metric.keys())
+                )
+            )
+        return stopper.step_score(score, self.model)
+
     def train(self):
         self.preprocess()
         stopper = EarlyStopping(self.args.patience, self._checkpoint)
@@ -240,7 +269,9 @@ class NodeClassification(BaseFlow):
                 self.writer.add_scalars('loss', {'train': train_loss, 'valid': val_loss}, global_step=epoch)
                 for mode in modes:
                     self.writer.add_scalars(f'metric_{mode}', metric_dict[mode], global_step=epoch)
-                early_stop = stopper.loss_step(val_loss, self.model)
+                early_stop = self._early_stop_step(
+                    stopper, val_loss, metric_dict['valid']
+                )
                 if early_stop:
                     self.logger.train_info('Early Stop!\tEpoch:' + str(epoch))
                     break

--- a/tests/test_hcan_config.py
+++ b/tests/test_hcan_config.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from openhgnn.config import Config
+from openhgnn.trainerflow.dhcan_trainer import DHCANTrainer
+
+
+def test_hcan_default_config_is_utf8_and_loadable():
+    config_path = Path(__file__).parents[1] / "openhgnn" / "config.ini"
+
+    config = Config(
+        file_path=str(config_path),
+        model="HCAN",
+        dataset="HGBn-ACM",
+        task="node_classification",
+        gpu=-1,
+    )
+
+    assert config.hidden_dim == 64
+    assert config.max_hop == 2
+    assert config.early_stop_metric == "Micro_f1"
+
+
+def test_dhcan_uses_decoupled_training_defaults():
+    config_path = Path(__file__).parents[1] / "openhgnn" / "config.ini"
+
+    config = Config(
+        file_path=str(config_path),
+        model="DHCAN",
+        dataset="ogbn-mag",
+        task="node_classification",
+        gpu=0,
+    )
+
+    assert config.cache_device == "cpu"
+    assert config.cache_target_on_gpu is True
+    assert config.batch_size == 65536
+
+
+def test_dhcan_trainer_rejects_unsupported_tasks():
+    with pytest.raises(ValueError, match="node classification only"):
+        DHCANTrainer(SimpleNamespace(task="link_prediction"))

--- a/tests/test_hcan_model.py
+++ b/tests/test_hcan_model.py
@@ -1,0 +1,308 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+dgl = pytest.importorskip("dgl")
+
+from openhgnn.models import build_model
+
+
+def _toy_graph():
+    return dgl.heterograph(
+        {
+            ("author", "writes", "paper"): (
+                torch.tensor([0, 1, 1]),
+                torch.tensor([0, 1, 2]),
+            ),
+            ("paper", "written-by", "author"): (
+                torch.tensor([0, 1, 2]),
+                torch.tensor([0, 1, 1]),
+            ),
+        },
+        num_nodes_dict={"author": 2, "paper": 3},
+    )
+
+
+def _args(task, out_dim):
+    return SimpleNamespace(
+        hidden_dim=8,
+        out_dim=out_dim,
+        num_layers=1,
+        max_hop=2,
+        num_heads=2,
+        dropout=0.0,
+        attn_activation="identity",
+        task=task,
+    )
+
+
+def _features():
+    return {
+        "author": torch.randn(2, 8),
+        "paper": torch.randn(3, 8),
+    }
+
+
+def test_hcan_node_classification_outputs_logits():
+    hg = _toy_graph()
+    model = build_model("HCAN").build_model_from_args(
+        _args(task="node_classification", out_dim=4), hg
+    )
+
+    out = model(hg, _features())
+
+    assert out["author"].shape == (2, 4)
+    assert out["paper"].shape == (3, 4)
+
+
+def test_hcan_counterweight_payload_matches_equation_11_dimensions():
+    hg = _toy_graph()
+    model = build_model("HCAN").build_model_from_args(
+        _args(task="node_classification", out_dim=4), hg
+    )
+    layer = model.layers[0]
+
+    assert layer.value_head_dim * layer.num_heads == layer.hidden_dim // 2
+    assert not hasattr(layer, "out_linear")
+
+
+def test_hcan_reuses_type_projection_across_hop_tokens():
+    hg = _toy_graph()
+    model = build_model("HCAN").build_model_from_args(
+        _args(task="node_classification", out_dim=4), hg
+    )
+    layer = model.layers[0]
+
+    assert isinstance(layer.hop_mlp["author"], torch.nn.Sequential)
+    assert isinstance(layer.hop_mlp["paper"], torch.nn.Sequential)
+
+
+def test_hcan_relation_mean_matches_equation_5():
+    hg = _toy_graph()
+    model = build_model("HCAN").build_model_from_args(
+        _args(task="node_classification", out_dim=4), hg
+    )
+    layer = model.layers[0]
+    features = {
+        "author": torch.tensor([[2.0] * 8, [4.0] * 8]),
+        "paper": torch.tensor([[1.0] * 8, [3.0] * 8, [5.0] * 8]),
+    }
+
+    propagated = layer._all_relation_mean_propagation(hg, features)
+
+    assert torch.allclose(
+        propagated["paper"],
+        torch.tensor([[2.0] * 8, [4.0] * 8, [4.0] * 8]),
+    )
+    assert torch.allclose(
+        propagated["author"],
+        torch.tensor([[1.0] * 8, [4.0] * 8]),
+    )
+
+
+def test_hcan_requires_half_width_per_attention_payload():
+    hg = _toy_graph()
+    args = _args(task="node_classification", out_dim=4)
+    args.hidden_dim = 10
+
+    with pytest.raises(ValueError, match="twice num_heads"):
+        build_model("HCAN").build_model_from_args(args, hg)
+
+
+def test_hcan_link_prediction_outputs_embeddings():
+    hg = _toy_graph()
+    args = _args(task="link_prediction", out_dim=4)
+    model = build_model("HCAN").build_model_from_args(args, hg)
+
+    out = model(hg, _features())
+
+    assert args.out_dim == 8
+    assert out["author"].shape == (2, 8)
+    assert out["paper"].shape == (3, 8)
+
+
+def test_dhcan_node_classification_outputs_logits():
+    hg = _toy_graph()
+    model = build_model("DHCAN").build_model_from_args(
+        _args(task="node_classification", out_dim=4), hg
+    )
+
+    out = model(hg, _features())
+
+    assert out["author"].shape == (2, 4)
+    assert out["paper"].shape == (3, 4)
+
+
+def test_dhcan_link_prediction_outputs_embeddings():
+    hg = _toy_graph()
+    args = _args(task="link_prediction", out_dim=4)
+    model = build_model("DHCAN").build_model_from_args(args, hg)
+
+    out = model(hg, _features())
+
+    assert args.out_dim == 8
+    assert out["author"].shape == (2, 8)
+    assert out["paper"].shape == (3, 8)
+
+
+def test_dhcan_paper_name_alias():
+    assert build_model("D-HCAN") is build_model("DHCAN")
+
+
+def test_dhcan_precomputes_only_valid_paths_and_reuses_cache():
+    hg = _toy_graph()
+    features = _features()
+    features["author"].requires_grad_()
+    features["paper"].requires_grad_()
+    model = build_model("DHCAN").build_model_from_args(
+        _args(task="node_classification", out_dim=4), hg
+    )
+
+    first = model(hg, features)
+    layer = model.layers[0]
+    cached_ids = [id(token) for token in layer._cached_tokens]
+    second = model(hg, {key: value + 10 for key, value in features.items()})
+    sum(value.sum() for value in first.values()).backward()
+
+    assert layer.num_channels == 2
+    assert (
+        layer.channel_proj["paper"][0][0].weight.data_ptr()
+        != layer.channel_proj["paper"][1][0].weight.data_ptr()
+    )
+    assert cached_ids == [id(token) for token in layer._cached_tokens]
+    assert all(torch.allclose(first[key], second[key]) for key in first)
+    assert features["author"].grad is None
+    assert features["paper"].grad is None
+    assert any(parameter.grad is not None for parameter in model.parameters())
+
+
+def test_dhcan_reuses_relation_path_prefixes():
+    hg = dgl.heterograph(
+        {
+            ("node", "left", "node"): (torch.tensor([0]), torch.tensor([1])),
+            ("node", "right", "node"): (torch.tensor([1]), torch.tensor([0])),
+        },
+        num_nodes_dict={"node": 2},
+    )
+    model = build_model("DHCAN").build_model_from_args(
+        _args(task="node_classification", out_dim=2), hg
+    )
+    layer = model.layers[0]
+    relation_propagate = layer._relation_propagate
+    call_count = 0
+
+    def counted_propagation(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        return relation_propagate(*args, **kwargs)
+
+    layer._relation_propagate = counted_propagation
+    tokens = list(layer._generate_decoupled_tokens(hg, {"node": _features()["author"]}))
+
+    assert len(tokens) == 4
+    assert call_count == 6
+
+
+def test_dhcan_clear_cache_recomputes_features():
+    hg = _toy_graph()
+    model = build_model("DHCAN").build_model_from_args(
+        _args(task="node_classification", out_dim=4), hg
+    )
+    model.eval()
+    first = model(hg, _features())
+    model.clear_cache()
+    second = model(hg, {key: value + 10 for key, value in _features().items()})
+
+    assert any(not torch.allclose(first[key], second[key]) for key in first)
+
+
+def test_dhcan_streaming_fusion_matches_concatenation():
+    hg = _toy_graph()
+    features = _features()
+    model = build_model("DHCAN").build_model_from_args(
+        _args(task="node_classification", out_dim=4), hg
+    )
+    model.eval()
+
+    actual = model(hg, features, return_emb=True)
+    layer = model.layers[0]
+    for ntype in hg.ntypes:
+        projected = []
+        for token in layer._cached_tokens:
+            if ntype in token:
+                token_features = token[ntype].to(features[ntype].device)
+                mask = token_features.abs().sum(dim=-1, keepdim=True) > 0
+                projected.append(
+                    layer.channel_proj[ntype][len(projected)](token_features)
+                    * mask.to(torch.float32)
+                )
+            else:
+                projected.append(
+                    features[ntype].new_zeros(
+                        hg.num_nodes(ntype), layer.hidden_dim
+                    )
+                )
+        expected = layer.semantic_fusion[ntype](torch.cat(projected, dim=-1))
+
+        assert torch.allclose(actual[ntype], expected, atol=1e-6)
+
+
+def test_dhcan_attention_includes_center_node():
+    hg = dgl.heterograph(
+        {
+            ("node", "link", "node"): (
+                torch.tensor([0, 1]),
+                torch.tensor([1, 0]),
+            )
+        },
+        num_nodes_dict={"node": 2},
+    )
+    args = _args(task="node_classification", out_dim=2)
+    args.max_hop = 1
+    model = build_model("DHCAN").build_model_from_args(args, hg)
+    layer = model.layers[0]
+    base = torch.zeros(2, layer.token_dim)
+    base[:, 0] = torch.tensor([1.0, 2.0])
+    token = next(layer._generate_decoupled_tokens(hg, {"node": base}))
+
+    attended = layer._non_parametric_attention(hg, {"node": base}, token)
+
+    expected = torch.zeros_like(base)
+    expected[:, 0] = 5.0 / 3.0
+    assert torch.allclose(attended["node"], expected)
+
+
+def test_dhcan_decodes_cached_node_batch():
+    hg = _toy_graph()
+    features = _features()
+    model = build_model("DHCAN").build_model_from_args(
+        _args(task="node_classification", out_dim=4), hg
+    )
+    model.eval()
+    model.precompute(hg, features)
+
+    node_idx = torch.tensor([2, 0])
+    batch_logits = model.forward_cached("paper", node_idx)
+    full_logits = model(hg, features)["paper"]
+
+    assert torch.allclose(batch_logits, full_logits[node_idx], atol=1e-6)
+
+
+def test_dhcan_target_cache_matches_full_cache():
+    hg = _toy_graph()
+    features = _features()
+    model = build_model("DHCAN").build_model_from_args(
+        _args(task="node_classification", out_dim=4), hg
+    )
+    model.eval()
+
+    model.precompute(hg, features)
+    full_logits = model.forward_cached("paper")
+    model.clear_cache()
+    target_cache = model.precompute(hg, features, target_ntype="paper")
+    target_logits = model.forward_cached("paper")
+
+    assert all(set(token).issubset({"paper"}) for token in target_cache)
+    assert any("paper" in token for token in target_cache)
+    assert torch.allclose(target_logits, full_logits, atol=1e-6)

--- a/tests/test_node_classification_early_stop.py
+++ b/tests/test_node_classification_early_stop.py
@@ -1,0 +1,40 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+pytest.importorskip("dgl")
+
+from openhgnn.trainerflow.node_classification import NodeClassification
+
+
+def _flow(metric):
+    flow = object.__new__(NodeClassification)
+    flow.args = SimpleNamespace(early_stop_metric=metric)
+    flow.model = Mock()
+    return flow
+
+
+def test_early_stop_uses_loss_by_default():
+    flow = _flow("loss")
+    stopper = Mock()
+    flow._early_stop_step(
+        stopper, 1.25, {"Micro_f1": 0.8, "Macro_f1": 0.7}
+    )
+
+    stopper.loss_step.assert_called_once_with(1.25, flow.model)
+
+
+def test_early_stop_uses_named_metric_case_insensitively():
+    flow = _flow("micro_F1")
+    stopper = Mock()
+    flow._early_stop_step(
+        stopper, 1.25, {"Micro_f1": 0.8, "Macro_f1": 0.7}
+    )
+
+    stopper.step_score.assert_called_once_with(0.8, flow.model)
+
+
+def test_early_stop_rejects_unknown_metric():
+    with pytest.raises(ValueError, match="not found"):
+        _flow("accuracy")._early_stop_step(Mock(), 1.25, {"Micro_f1": 0.8})


### PR DESCRIPTION
## Description

本 PR 根据 ICDE 2025 论文 *Effective and Scalable Heterogeneous Graph Neural Network Framework with Convolution-oriented Attention*，为 OpenHGNN 增加 V-HCAN 和 D-HCAN。

## Changes

- 新增 `HCAN`（V-HCAN），对应论文算法 1 和公式 (4)-(11)：
  - 节点类型特定的特征投影；
  - 0 到 K 跳非参数图卷积与类型特定 MLP；
  - 关系感知、多头 convolution-oriented attention；
  - counterweight payload `1 - gamma`；
  - 高、低注意力各产生一半维度，拼接后按公式 (11) 与类型残差直接相加。
- 新增 `DHCAN` / `D-HCAN`，对应论文公式 (13)-(15)：
  - 枚举类型兼容的 K 跳关系序列；
  - 使用关系特定的行归一化均值传播生成通道；
  - 按原始点积分数归一化，并将中心节点计入 `N_i*`；
  - 对非零通道执行前馈投影、拼接和语义融合。
- 新增 D-HCAN 专用节点分类 trainer：在 CPU 上完成无梯度预计算，只缓存目标节点类型，并在 GPU 上按目标节点 batch 训练，避免 OGB-MAG 全图端到端训练显存溢出。
- 增加 HCAN/D-HCAN 配置、模型和 trainer 注册、模型文档及 README 索引。
- OGB-MAG 仅在 SeHGNN 被选择时执行 SeHGNN 专用预处理，避免其他模型触发无关的大规模稀疏矩阵构造。
- 节点分类流程支持按验证集 `Micro_f1` 等指标早停，V-HCAN 不再按损失选择 checkpoint。

## Formula Correspondence

- V-HCAN 的关系均值传播、关系内 softmax、counterweight payload 和公式 (11) 输出维度均有针对性测试。
- D-HCAN 使用手算样例验证了公式 (13)-(15)，覆盖 K 跳卷积、中心节点、未经过 softmax 的原始分数归一化和注意力聚合。
- D-HCAN 的关系路径前缀会复用，目标类型缓存与完整缓存的输出经过等价性测试。

## Verification

- `22 passed`：

  ```bash
  python -m pytest -o addopts= tests/test_hcan_model.py tests/test_hcan_config.py tests/test_node_classification_early_stop.py -q
  ```

- `python -m compileall` 通过。
- `git diff --cached --check` 通过。
- 最终公式版 V-HCAN 在 HGBn-ACM 单次验证中得到 Macro-F1 96.30%、Micro-F1 96.13%，训练和早停流程正常。
- D-HCAN 已在完整 OGB-MAG 上完成单次大规模训练验证；`batch_size=10000` 时平均训练时间约 6.30 秒/轮，与论文表 VIII 的 5.89 秒/轮接近。

## Reproduction Note

论文没有发布官方代码，也没有完整给出 D-HCAN 的隐藏维度、前馈网络深度、dropout、batch size，以及 OGB-MAG 无特征节点和反向关系的具体预处理方式。因此，本 PR 以论文公开的数学定义为实现依据，并保证公式级对应；对于论文未公开的工程细节采用 OpenHGNN 的现有数据处理方式和显式配置项，不声明默认配置可以逐项复现表 VIII 的五次运行均值。

在当前 OpenHGNN 预处理和已测试默认结构下，D-HCAN 的单次 OGB-MAG 准确率未达到论文表 VIII。该差异在 PR 中明确披露，不通过标签传播、多阶段训练或额外嵌入等论文未说明的技巧追数值。

## Checklist

- [x] PR 标题以 `[Model]` 开头
- [x] V-HCAN 和 D-HCAN 实现完整
- [x] 新增代码具有测试覆盖
- [x] 已增加模型文档和 README 索引
- [x] 不包含数据集、checkpoint、实验日志或服务器信息